### PR TITLE
Add verification for Google Search Console, allow Google to scrape website

### DIFF
--- a/googlea6b22c752bdd763a.html
+++ b/googlea6b22c752bdd763a.html
@@ -1,0 +1,1 @@
+google-site-verification: googlea6b22c752bdd763a.html

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-# robotstxt.org - if ENV production variable is false robots will be disallowed.
+Allow: /
 
-  Disallow: /
+Sitemap: https://alemannia-makaria.de/sitemap.xml
 


### PR DESCRIPTION
Derzeit ist es Suchmaschinen per robots.txt explizit **verboten** die Website zu crawlen und die Details zu veröffentlichen.

Ergebnis:

![Screenshot from 2020-12-30 09-06-11](https://user-images.githubusercontent.com/265630/103338432-bbaddb00-4a7e-11eb-8840-f8c00f57978b.png)

![Screenshot from 2020-12-30 09-08-50](https://user-images.githubusercontent.com/265630/103338439-c1a3bc00-4a7e-11eb-8c27-d9d534356092.png)

Ref:
https://developers.google.com/search/docs/advanced/robots/create-robots-txt